### PR TITLE
Relax types in call: allow to pass tuples to avoid allocations

### DIFF
--- a/src/segment_integrator.jl
+++ b/src/segment_integrator.jl
@@ -252,8 +252,8 @@ function initialize!(O::SegmentIntegrator{T, UT}, sol; time = 0, kwargs...) wher
 		end
 		function integrator!(
 			result::AbstractArray{Tv, 1},
-			w::Array{Array{Tv, 1}, 1},    # world coordinates
-			b::Array{Array{Tv, 1}, 1},    # barycentric coordinates (w.r.t. item geometry)
+			w,#::Array{Array{Tv, 1}, 1},    # world coordinates
+			b,#::Array{Array{Tv, 1}, 1},    # barycentric coordinates (w.r.t. item geometry)
 			item, # cell in which the segment lies (completely)
 		) where {Tv}
 


### PR DESCRIPTION
Needed to reduce allocations in https://github.com/j-fu/VoronoiFVM.jl/pull/129
